### PR TITLE
update peer dependency to allow newer versions of RN

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "author": "Roy Ben-Sasson",
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "0.51.0"
+    "react-native": "^0.51.0"
   }
 }


### PR DESCRIPTION
I am using React Native 0.59.8 and I am getting a peer dependency warning in my console