### PR TITLE
update android manual linking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 #### Android
 
-1. Open up `android/app/src/main/java/[...]/MainActivity.java`
+1. Open up `android/app/src/main/java/[...]/MainApplication.java`
   - Add `import com.como.RNTShadowView.ShadowViewPackage;` to the imports at the top of the file
   - Add `new ShadowViewPackage()` to the list returned by the `getPackages()` method
 2. Append the following lines to `android/settings.gradle`:


### PR DESCRIPTION
After RN version 0.29 plugins are supposed to be installed in MainApplication.java instead of MainActivity.java

See the [React Native v29 Release Notes](https://github.com/facebook/react-native/releases/tag/v0.29.0 ).